### PR TITLE
Replace "director" with "director/build/director" for cjs support

### DIFF
--- a/src/directorRe.re
+++ b/src/directorRe.re
@@ -1,6 +1,6 @@
 type t;
 
 external makeRouter : Js.t {..} => t =
-  "Router" [@@bs.module "director"] [@@bs.new];
+  "Router" [@@bs.module "director/build/director"] [@@bs.new];
 
 external init : t => string => unit = "init" [@@bs.send];


### PR DESCRIPTION
This commit replaces the "director" module with "director/build/director". Per this issue: https://github.com/flatiron/director/issues/332